### PR TITLE
Explicitly set supervisord.conf path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,4 +101,4 @@ RUN set -xe; \
 
 EXPOSE 5000/udp 8181/tcp 8282/udp
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]


### PR DESCRIPTION
Supervisord complains that no path to a supervisord.conf file is explicitly set with `-c`-Flag while running under a root user.

This fixes this specific error and prevents usage of the default supervisord.conf file (which actually throws CRIT errors on Startup because it has bad configuration).

I'm building on ARM, please check whether this is also a problem for amd64 builds before merging :-) However, this is a good fix nonetheless.